### PR TITLE
Improve error handling for chat client

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -141,7 +141,8 @@ class ChatCLI(cmd.Cmd):
         target, text = parts
         if target in self.peers:
             thost, tport = self.peers[target]
-            client_send_msg(thost, tport, self.config['handle'], text)
+            if not client_send_msg(thost, tport, self.config['handle'], text):
+                print(f"Fehler beim Senden an {target}.")
         else:
             print("Unbekannter Nutzer.")
 
@@ -160,10 +161,8 @@ class ChatCLI(cmd.Cmd):
             return
 
         for peer_handle, (phost, pport) in self.peers.items():
-            try:
-                client_send_msg(phost, pport, self.config['handle'], text)
-            except Exception as e:
-                print(f"Fehler beim Senden an {peer_handle}: {e}")
+            if not client_send_msg(phost, pport, self.config['handle'], text):
+                print(f"Fehler beim Senden an {peer_handle}.")
         print("Nachricht an alle gesendet.")
 
     def do_img(self, arg):
@@ -179,9 +178,8 @@ class ChatCLI(cmd.Cmd):
         target, path = parts
         if target in self.peers:
             thost, tport = self.peers[target]
-            success = client_send_img(thost, tport, self.config['handle'], path)
-            if not success:
-                print("Datei nicht gefunden.")
+            if not client_send_img(thost, tport, self.config['handle'], path):
+                print("Bild konnte nicht gesendet werden.")
         else:
             print("Unbekannter Nutzer.")
 

--- a/client.py
+++ b/client.py
@@ -52,21 +52,35 @@ def client_send_leave(config):
     _send_discovery(msg, config)
 
 #Funktion zum Senden einer MSG-Nachricht an einen bestimmten Host und Port
-def client_send_msg(target_host: str, target_port: int, from_handle: str, text: str):
-    """Sende eine Textnachricht über TCP."""
-    with socket.create_connection((target_host, target_port)) as sock:
-        data = build_msg(from_handle, text)
-        sock.sendall(data)
+def client_send_msg(target_host: str, target_port: int, from_handle: str, text: str) -> bool:
+    """Sende eine Textnachricht über TCP.
+
+    Gibt ``True`` zurück, wenn die Verbindung erfolgreich aufgebaut und die
+    Nachricht gesendet wurde. Tritt beim Verbindungsaufbau ein Fehler auf,
+    wird ``False`` geliefert und der Fehler auf ``stdout`` ausgegeben.
+    """
+    try:
+        with socket.create_connection((target_host, target_port)) as sock:
+            data = build_msg(from_handle, text)
+            sock.sendall(data)
+        return True
+    except OSError as e:
+        print(f"[Client] Verbindung zu {target_host}:{target_port} fehlgeschlagen: {e}")
+        return False
     
 #Funktion zum Senden eines Bildes an einen bestimmten Host und Port
-def client_send_img(target_host: str, target_port: int, from_handle: str, img_path: str):
+def client_send_img(target_host: str, target_port: int, from_handle: str, img_path: str) -> bool:
     """Sende eine Bildnachricht über TCP."""
     if not os.path.isfile(img_path):
         return False
     size = os.path.getsize(img_path)
-    with socket.create_connection((target_host, target_port)) as sock:
-        header = build_img(from_handle, size)
-        sock.sendall(header)
-        with open(img_path, 'rb') as f:
-            sock.sendall(f.read())
-    return True
+    try:
+        with socket.create_connection((target_host, target_port)) as sock:
+            header = build_img(from_handle, size)
+            sock.sendall(header)
+            with open(img_path, 'rb') as f:
+                sock.sendall(f.read())
+        return True
+    except OSError as e:
+        print(f"[Client] Verbindung zu {target_host}:{target_port} fehlgeschlagen: {e}")
+        return False


### PR DESCRIPTION
## Summary
- catch connection failures in `client_send_msg`/`client_send_img`
- handle failed sends in CLI commands

## Testing
- `python -m py_compile client.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684d69b488888333a81d5a318582b3e0