### PR TITLE
Improve port selection for join

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Dieses Projekt implementiert einen einfachen Peer-to-Peer Messenger.
 
 Mehrere Instanzen lassen sich parallel starten, ohne einen Port manuell zu vergeben. Beim Beitritt zu einem Chat wählt der Client automatisch einen freien TCP-Port und teilt ihn über den Discovery-Dienst mit. Stelle lediglich sicher, dass die Broadcast-Adresse in `config.toml` auf `127.255.255.255` gesetzt ist, wenn du Discovery lokal testen möchtest.
 
+Möchtest du nur bestimmte Ports verwenden, kannst du in `config.toml` das Array
+`auto_ports` hinterlegen. Enthält es z.B. `[5005, 5006, 5007]`, wählt der
+Client beim `join` zufällig einen freien Port aus dieser Liste.
+
 ## Peer-to-Peer im Netzwerk
 
 Sollen sich Clients auf unterschiedlichen Rechnern finden, muss die Broadcast-Adresse auf das LAN angepasst werden. Gib sie entweder in der Konfiguration an oder direkt beim Starten. Achte darauf, keine Loopback-Adresse (`127.x.x.x`) zu verwenden, da sonst alle Peers ihre eigene Adresse melden:

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ import threading
 import time
 import queue
 import socket
+import random
 from client import client_send_join, client_send_leave, client_send_who, client_send_msg, client_send_img
 
 # Timeout für Auto-Reply (in Sekunden) – bleibt vorerst fest im Code, kann aber auch in config ausgelagert werden
@@ -30,6 +31,33 @@ class ChatCLI(cmd.Cmd):
         self._stop_event = threading.Event()
         self._poll_thread = threading.Thread(target=self._poll_queues, daemon=True)
         self._poll_thread.start()
+
+    def _choose_port(self) -> int:
+        """Wählt einen freien TCP-Port aus der Konfiguration.
+
+        Ist in ``config['auto_ports']`` eine Liste mit Ports angegeben, wird der
+        erste freie aus dieser Liste verwendet. Andernfalls (oder falls keiner
+        verfügbar ist) wird ein zufälliger freier Port gewählt.
+        """
+        ports = self.config.get('auto_ports', [])
+        if isinstance(ports, list) and ports:
+            ports = list(ports)
+            random.shuffle(ports)
+            for p in ports:
+                tmp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    tmp.bind(("", int(p)))
+                    tmp.close()
+                    return int(p)
+                except OSError:
+                    tmp.close()
+                    continue
+            print("Keiner der angegebenen Ports war frei. Wähle zufälligen Port.")
+        tmp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tmp.bind(("", 0))
+        port = tmp.getsockname()[1]
+        tmp.close()
+        return port
 
     def _poll_queues(self):
         while not self._stop_event.is_set():
@@ -89,11 +117,8 @@ class ChatCLI(cmd.Cmd):
             return
         handle = parts[0]
 
-        # freien TCP-Port wählen
-        tmp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        tmp_sock.bind(("", 0))
-        port = tmp_sock.getsockname()[1]
-        tmp_sock.close()
+        # freien TCP-Port wählen (ggf. aus vordefinierter Liste)
+        port = self._choose_port()
 
         self.config['handle'] = handle
         self.config['port'] = port
@@ -141,7 +166,8 @@ class ChatCLI(cmd.Cmd):
         target, text = parts
         if target in self.peers:
             thost, tport = self.peers[target]
-            client_send_msg(thost, tport, self.config['handle'], text)
+            if not client_send_msg(thost, tport, self.config['handle'], text):
+                print(f"Fehler beim Senden an {target}.")
         else:
             print("Unbekannter Nutzer.")
 
@@ -160,10 +186,8 @@ class ChatCLI(cmd.Cmd):
             return
 
         for peer_handle, (phost, pport) in self.peers.items():
-            try:
-                client_send_msg(phost, pport, self.config['handle'], text)
-            except Exception as e:
-                print(f"Fehler beim Senden an {peer_handle}: {e}")
+            if not client_send_msg(phost, pport, self.config['handle'], text):
+                print(f"Fehler beim Senden an {peer_handle}.")
         print("Nachricht an alle gesendet.")
 
     def do_img(self, arg):
@@ -179,9 +203,8 @@ class ChatCLI(cmd.Cmd):
         target, path = parts
         if target in self.peers:
             thost, tport = self.peers[target]
-            success = client_send_img(thost, tport, self.config['handle'], path)
-            if not success:
-                print("Datei nicht gefunden.")
+            if not client_send_img(thost, tport, self.config['handle'], path):
+                print("Bild konnte nicht gesendet werden.")
         else:
             print("Unbekannter Nutzer.")
 

--- a/client.py
+++ b/client.py
@@ -52,21 +52,35 @@ def client_send_leave(config):
     _send_discovery(msg, config)
 
 #Funktion zum Senden einer MSG-Nachricht an einen bestimmten Host und Port
-def client_send_msg(target_host: str, target_port: int, from_handle: str, text: str):
-    """Sende eine Textnachricht über TCP."""
-    with socket.create_connection((target_host, target_port)) as sock:
-        data = build_msg(from_handle, text)
-        sock.sendall(data)
+def client_send_msg(target_host: str, target_port: int, from_handle: str, text: str) -> bool:
+    """Sende eine Textnachricht über TCP.
+
+    Gibt ``True`` zurück, wenn die Verbindung erfolgreich aufgebaut und die
+    Nachricht gesendet wurde. Tritt beim Verbindungsaufbau ein Fehler auf,
+    wird ``False`` geliefert und der Fehler auf ``stdout`` ausgegeben.
+    """
+    try:
+        with socket.create_connection((target_host, target_port)) as sock:
+            data = build_msg(from_handle, text)
+            sock.sendall(data)
+        return True
+    except OSError as e:
+        print(f"[Client] Verbindung zu {target_host}:{target_port} fehlgeschlagen: {e}")
+        return False
     
 #Funktion zum Senden eines Bildes an einen bestimmten Host und Port
-def client_send_img(target_host: str, target_port: int, from_handle: str, img_path: str):
+def client_send_img(target_host: str, target_port: int, from_handle: str, img_path: str) -> bool:
     """Sende eine Bildnachricht über TCP."""
     if not os.path.isfile(img_path):
         return False
     size = os.path.getsize(img_path)
-    with socket.create_connection((target_host, target_port)) as sock:
-        header = build_img(from_handle, size)
-        sock.sendall(header)
-        with open(img_path, 'rb') as f:
-            sock.sendall(f.read())
-    return True
+    try:
+        with socket.create_connection((target_host, target_port)) as sock:
+            header = build_img(from_handle, size)
+            sock.sendall(header)
+            with open(img_path, 'rb') as f:
+                sock.sendall(f.read())
+        return True
+    except OSError as e:
+        print(f"[Client] Verbindung zu {target_host}:{target_port} fehlgeschlagen: {e}")
+        return False

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,11 @@ handle    = "user_name"
 # Client-Server-UDP-Port dieses Rechners (z. B. 5001 oder 5002)
 port      = 5005
 
+# Liste möglicher TCP-Ports, die beim Beitreten verwendet werden dürfen.
+# Ist keine Liste angegeben oder sie ist leer, wählt der Client automatisch
+# einen freien Port.
+auto_ports = [5005, 5006, 5007]
+
 # SLCP-Discovery-Port (muss auf allen Peers gleich sein, z. B. 4000)
 whoisport = 4000
 


### PR DESCRIPTION
## Summary
- implement random choice from configured port list for different peers
- update README to clarify random selection

## Testing
- `python -m py_compile client.py cli.py server.py discovery_service.py main.py slcp_handler.py ipc_handler.py gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684d69b488888333a81d5a318582b3e0