### PR TITLE
Show images for sender with dark theme refresh

### DIFF
--- a/gui_tk.py
+++ b/gui_tk.py
@@ -1,8 +1,8 @@
 import tkinter as tk
 from tkinter import simpledialog, filedialog
+from PIL import Image, ImageTk
 import queue
 import time
-import sys
 import socket
 
 from client import (
@@ -46,35 +46,73 @@ class ChatGUI(tk.Tk):
     def _setup_ui(self):
         self.title("Messenger")
         self.geometry("800x600")
+        self.configure(bg="#2b2b2b")
 
-        main_frame = tk.Frame(self)
+        self.images = []
+
+        main_frame = tk.Frame(self, bg="#2b2b2b")
         main_frame.pack(fill="both", expand=True)
 
-        list_frame = tk.Frame(main_frame)
+        list_frame = tk.Frame(main_frame, bg="#2b2b2b")
         list_frame.pack(fill="both", expand=True, padx=5, pady=5)
 
-        chat_frame = tk.Frame(list_frame)
+        chat_frame = tk.Frame(list_frame, bg="#2b2b2b")
         chat_frame.pack(side="left", fill="both", expand=True)
 
-        self.chat_list = tk.Listbox(chat_frame, font=("Helvetica", 11))
-        self.chat_list.pack(side="left", fill="both", expand=True)
+        self.chat_text = tk.Text(
+            chat_frame,
+            font=("Helvetica", 11),
+            bg="#1e1e1e",
+            fg="#dcdcdc",
+            wrap="word",
+            state="disabled",
+        )
+        self.chat_text.pack(side="left", fill="both", expand=True)
 
-        peer_frame = tk.Frame(list_frame)
+        peer_frame = tk.Frame(list_frame, bg="#2b2b2b")
         peer_frame.pack(side="right", fill="y")
 
-        self.peer_list = tk.Listbox(peer_frame, width=20, font=("Helvetica", 11))
+        self.peer_list = tk.Listbox(
+            peer_frame, width=20, font=("Helvetica", 11), bg="#333", fg="#ffffff"
+        )
         self.peer_list.pack(side="left", fill="y")
 
-        bottom_frame = tk.Frame(main_frame)
+        bottom_frame = tk.Frame(main_frame, bg="#2b2b2b")
         bottom_frame.pack(fill="x", pady=5)
 
-        self.text_entry = tk.Text(bottom_frame, height=3, font=("Helvetica", 11))
+        self.text_entry = tk.Text(
+            bottom_frame, height=3, font=("Helvetica", 11), bg="#1e1e1e", fg="#dcdcdc"
+        )
         self.text_entry.pack(side="left", fill="both", expand=True)
 
-        self.image_btn = tk.Button(bottom_frame, text="📷", width=4, command=self.open_image_dialog)
+        self.image_btn = tk.Button(
+            bottom_frame,
+            text="📷",
+            width=4,
+            command=self.open_image_dialog,
+            bg="#007acc",
+            fg="#ffffff",
+            activebackground="#005f99",
+            highlightbackground="#2b2b2b",
+            relief="flat",
+            bd=0,
+        )
         self.image_btn.pack(side="left", padx=(5, 0))
 
-        self.send_btn = tk.Button(bottom_frame, text="Senden", width=10, command=self._send_message)
+        self.send_btn = tk.Button(
+            bottom_frame,
+            text="Senden",
+            width=10,
+            command=self._send_message,
+            bg="#007acc",
+            fg="#ffffff",
+            activebackground="#005f99",
+            activeforeground="#ffffff",
+            highlightbackground="#2b2b2b",
+            relief="flat",
+            bd=0,
+            highlightthickness=0,
+        )
         self.send_btn.pack(side="left", padx=5)
 
         self.text_entry.bind("<Return>", self._send_message_event)
@@ -106,13 +144,11 @@ class ChatGUI(tk.Tk):
                     if auto_msg and from_handle in self.peers:
                         thost, tport = self.peers[from_handle]
                         client_send_msg(thost, tport, self.config["handle"], auto_msg)
-                self.chat_list.insert("end", f"{from_handle}: {text}")
-                self.chat_list.yview_moveto(1)
+                self._append_text(f"{from_handle}: {text}\n")
             elif msg[0] == "IMG":
                 from_handle = msg[1]
                 path = msg[2]
-                self.chat_list.insert("end", f"[Bild von {from_handle}] {path}")
-                self.chat_list.yview_moveto(1)
+                self._append_image(from_handle, path)
         while True:
             try:
                 dmsg = self.disc_to_cli.get_nowait()
@@ -127,6 +163,28 @@ class ChatGUI(tk.Tk):
         self.peer_list.delete(0, "end")
         for h in sorted(self.peers.keys()):
             self.peer_list.insert("end", h)
+
+    def _append_text(self, text):
+        self.chat_text.configure(state="normal")
+        self.chat_text.insert("end", text)
+        self.chat_text.configure(state="disabled")
+        self.chat_text.see("end")
+
+    def _append_image(self, prefix, path):
+        try:
+            img = Image.open(path)
+            img.thumbnail((200, 200))
+            photo = ImageTk.PhotoImage(img)
+            self.images.append(photo)
+            self.chat_text.configure(state="normal")
+            if prefix:
+                self.chat_text.insert("end", f"{prefix}: ")
+            self.chat_text.image_create("end", image=photo)
+            self.chat_text.insert("end", "\n")
+            self.chat_text.configure(state="disabled")
+            self.chat_text.see("end")
+        except Exception:
+            self._append_text(f"[Bild {prefix}] {path}\n")
 
     def _send_message(self):
         self.last_activity = time.time()
@@ -145,29 +203,27 @@ class ChatGUI(tk.Tk):
                     host, port = self.peers[handle]
                     try:
                         client_send_msg(host, port, self.config["handle"], message)
-                        self.chat_list.insert("end", f"[Du -> {handle}] {message}")
+                        self._append_text(f"[Du -> {handle}] {message}\n")
                     except OSError as e:
-                        self.chat_list.insert("end", f"[Fehler] {e}")
+                        self._append_text(f"[Fehler] {e}\n")
                 else:
-                    self.chat_list.insert("end", "[Fehler] Unbekannter Nutzer")
+                    self._append_text("[Fehler] Unbekannter Nutzer\n")
             else:
-                self.chat_list.insert("end", "[Fehler] Syntax: msg <user> <text>")
-            self.chat_list.yview_moveto(1)
+                self._append_text("[Fehler] Syntax: msg <user> <text>\n")
             self.text_entry.delete("1.0", "end")
             return
 
         if text.startswith("msgall ") or text.startswith("msg all "):
             message = text.split(" ", 1)[1].split(" ", 1)[1] if text.startswith("msg all ") else text.split(" ", 1)[1]
             if not self.peers:
-                self.chat_list.insert("end", "[Fehler] Keine anderen Peers")
+                self._append_text("[Fehler] Keine anderen Peers\n")
             else:
                 for h, (host, port) in self.peers.items():
                     try:
                         client_send_msg(host, port, self.config["handle"], message)
                     except OSError as e:
-                        self.chat_list.insert("end", f"[Fehler] zu {h}: {e}")
-                self.chat_list.insert("end", f"[Du -> alle] {message}")
-            self.chat_list.yview_moveto(1)
+                        self._append_text(f"[Fehler] zu {h}: {e}\n")
+                self._append_text(f"[Du -> alle] {message}\n")
             self.text_entry.delete("1.0", "end")
             return
 
@@ -179,25 +235,22 @@ class ChatGUI(tk.Tk):
                     host, port = self.peers[handle]
                     try:
                         if client_send_img(host, port, self.config["handle"], path):
-                            self.chat_list.insert(
-                                "end", f"[Du -> {handle}] Bild gesendet: {path}"
-                            )
+                            self._append_image(f"Du -> {handle}", path)
                         else:
-                            self.chat_list.insert("end", "[Fehler] Datei nicht gefunden")
+                            self._append_text("[Fehler] Datei nicht gefunden\n")
                     except OSError as e:
-                        self.chat_list.insert("end", f"[Fehler] {e}")
+                        self._append_text(f"[Fehler] {e}\n")
                 else:
-                    self.chat_list.insert("end", "[Fehler] Unbekannter Nutzer")
+                    self._append_text("[Fehler] Unbekannter Nutzer\n")
             else:
-                self.chat_list.insert("end", "[Fehler] Syntax: img <user> <pfad>")
-            self.chat_list.yview_moveto(1)
+                self._append_text("[Fehler] Syntax: img <user> <pfad>\n")
             self.text_entry.delete("1.0", "end")
             return
 
         if text == "who":
             client_send_who(self.config)
-            self.chat_list.insert("end", "[Info] Peer-Liste angefordert")
-            self.chat_list.yview_moveto(1)
+            self.chat_text.configure(state="normal")
+            self._append_text("[Info] Peer-Liste angefordert\n")
             self.text_entry.delete("1.0", "end")
             return
 
@@ -205,19 +258,16 @@ class ChatGUI(tk.Tk):
             if self.joined:
                 client_send_leave(self.config)
                 self.joined = False
-                self.chat_list.insert("end", "[Info] Netzwerk verlassen")
+                self._append_text("[Info] Netzwerk verlassen\n")
             else:
-                self.chat_list.insert("end", "[Info] Nicht im Netzwerk")
-            self.chat_list.yview_moveto(1)
+                self._append_text("[Info] Nicht im Netzwerk\n")
             self.text_entry.delete("1.0", "end")
             return
 
         if text == "help":
-            self.chat_list.insert(
-                "end",
-                "Befehle: msg <user> <text>, msgall <text>, img <user> <pfad>, who, leave, help",
+            self._append_text(
+                "Befehle: msg <user> <text>, msgall <text>, img <user> <pfad>, who, leave, help\n"
             )
-            self.chat_list.yview_moveto(1)
             self.text_entry.delete("1.0", "end")
             return
 
@@ -229,10 +279,9 @@ class ChatGUI(tk.Tk):
             host, port = self.peers[handle]
             try:
                 client_send_msg(host, port, self.config["handle"], text)
-                self.chat_list.insert("end", f"[Du -> {handle}] {text}")
+                self._append_text(f"[Du -> {handle}] {text}\n")
             except OSError as e:
-                self.chat_list.insert("end", f"[Fehler] {e}")
-            self.chat_list.yview_moveto(1)
+                self._append_text(f"[Fehler] {e}\n")
         self.text_entry.delete("1.0", "end")
 
     def _send_message_event(self, event):
@@ -252,10 +301,9 @@ class ChatGUI(tk.Tk):
             if handle in self.peers:
                 host, port = self.peers[handle]
                 if client_send_img(host, port, self.config["handle"], filename):
-                    self.chat_list.insert(
-                        "end", f"[Du -> {handle}] Bild gesendet: {filename}"
-                    )
-                    self.chat_list.yview_moveto(1)
+                    self._append_image(f"Du -> {handle}", filename)
+                else:
+                    self._append_text("[Fehler] Datei nicht gefunden\n")
 
     def on_close(self):
         if self.joined:


### PR DESCRIPTION
## Summary
- drop scrollbars from chat and peer lists
- add helper methods for displaying text and images inline
- style buttons with modern flat look
- display sent images in the chat window
- ensure `Senden` button text is visible on Linux
- remove unused sys import

## Testing
- `python3 -m py_compile *.py`
- `timeout 5 xvfb-run -s "-screen 0 1024x768x24" python3 gui_tk.py --config config.toml`


------
https://chatgpt.com/codex/tasks/task_e_68516a98f95c83338ced55a8e292048c